### PR TITLE
Focusing the filter textbox once the form has loaded

### DIFF
--- a/src/ServiceBouncer/MainForm.cs
+++ b/src/ServiceBouncer/MainForm.cs
@@ -71,6 +71,9 @@ namespace ServiceBouncer
                 await Connect();
                 dataGridView.Sort(dataGridName, ListSortDirection.Ascending);
             });
+
+            // UX: To make it easy to start searching as soon as you launch.
+            this.toolStripFilterBox.Focus();
         }
 
         private void FormActivated(object sender, EventArgs e)


### PR DESCRIPTION
## What Changed?

This focuses the filter textbox as soon as you launch the app, saving you a click and letting you find your service(s) quickly.

### Reasoning

To me, filtering is one of the key things that sets this app apart from the built-in services app in Windows, so I find it useful to focus the filter box by default (to help me get to where I'm going faster).